### PR TITLE
Fix: Navbar mobile pannel background and responsiveness fixed

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -75,12 +75,12 @@ const Navbar = () => {
         {/* Mobile Navigation */}
         {isMenuOpen && (
           <div className="lg:hidden fixed inset-0 bg-white/95 backdrop-blur-md pt-32 px-4 z-40 animate-fade-in">
-            <div className="flex flex-col space-y-6 items-center">
+            <div className="flex  flex-col space-y-6 bg-white p-4 items-center">
               {navLinks.map((link) => (
                 <Link
                   key={link.name}
                   to={link.href}
-                  className="text-icosom-dark text-lg font-medium"
+                  className="text-icosom-dark  text-lg font-medium"
                   onClick={() => setIsMenuOpen(false)}
                 >
                   {link.name}

--- a/src/components/OrganizingCommittee.tsx
+++ b/src/components/OrganizingCommittee.tsx
@@ -161,7 +161,7 @@ const OrganizingCommittee = () => {
       <div className="max-w-6xl mx-auto">
         {/* Tagline  */}
         <div className="text-center font-bold mb-16">
-          <h2 className="text-4xl mb-4">
+          <h2 className="text-4xl flex flex-wrap justify-center mb-4">
             <span className="text-black">Committee</span>
             <span className="text-black ml-4">Members</span>
           </h2>
@@ -193,7 +193,7 @@ const OrganizingCommittee = () => {
         {/* Patrons  */}
         <div className="mt-24 flex flex-col justify-center items-center gap-12">
           <h1 className="text-4xl font-semibold">Patron</h1>
-          <div className="flex justify-center items-center gap-16">
+          <div className="flex flex-col sm:flex-row justify-center items-center gap-16">
             {/* Patron 1 */}
             <div className="border px-12 py-8 bg-slate-50 rounded-lg shadow hover:shadow-md ">
               <div className="flex flex-col gap-8">
@@ -215,7 +215,7 @@ const OrganizingCommittee = () => {
 
             {/* Patron 2 */}
             <div className="border px-12 py-8 bg-slate-50 rounded-lg shadow hover:shadow-md ">
-              <div className="flex flex-col gap-8">
+              <div className="h-full flex flex-col gap-8">
                 <img
                   src={mainHeads[2].image}
                   alt={mainHeads[2].fullName}
@@ -237,10 +237,10 @@ const OrganizingCommittee = () => {
         {/* General Chair  */}
         <div className="mt-24 flex flex-col justify-center items-center gap-12">
           <h1 className="text-4xl font-semibold">General Chair</h1>
-          <div className="flex justify-center items-center gap-16">
+          <div className="flex flex-col sm:flex-rowjustify-center items-center gap-16">
             {/* General Chair 1 */}
             <div className="border px-12 py-8 bg-slate-50 rounded-lg shadow hover:shadow-md ">
-              <div className="flex flex-col gap-8">
+              <div className="h-full flex flex-col gap-8">
                 <img
                   src={genralChairMembers[0].image}
                   alt={genralChairMembers[0].fullName}
@@ -301,7 +301,7 @@ const OrganizingCommittee = () => {
         <div className="mt-24 flex flex-col justify-center items-center gap-12">
           <h1 className="text-4xl font-semibold">General Co-Chair</h1>
           <div className="flex justify-center items-center gap-16">
-            <div className="flex justify-center items-center gap-16">
+            <div className="flex flex-col sm:flex-row justify-center items-center gap-16">
               {generalCoChairMembers.map((data, idx) => {
                 return (
                   <div className="border px-12 py-8 bg-slate-50 rounded-lg shadow hover:shadow-md">
@@ -331,7 +331,7 @@ const OrganizingCommittee = () => {
         <div className="mt-24 flex flex-col justify-center items-center gap-12">
           <h1 className="text-4xl font-semibold">Program Chair</h1>
           <div className="flex justify-center items-center gap-16">
-            <div className="flex justify-center items-center gap-16">
+            <div className="flex flex-col sm:flex-row justify-center items-center gap-16">
               {programChairMembers.map((data, idx) => {
                 return (
                   <div className="border px-12 py-8 bg-slate-50 rounded-lg shadow hover:shadow-md">
@@ -361,7 +361,7 @@ const OrganizingCommittee = () => {
         <div className="mt-24 flex flex-col justify-center items-center gap-12">
           <h1 className="text-4xl font-semibold">Technical Program Chair</h1>
           <div className="flex justify-center items-center gap-16">
-            <div className="flex justify-center items-center gap-16">
+            <div className="flex flex-col sm:flex-row justify-center items-center gap-16">
               {programChairMembers.map((data, idx) => {
                 return (
                   <div className="border px-12 py-8 bg-slate-50 rounded-lg shadow hover:shadow-md">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,7 +13,7 @@ import KeyNoteSpeakers from '@/components/KeyNoteSpeakers';
 
 const Index = () => {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen min-w-full">
       <Navbar />
       <HeroSection />
       <AboutSection />


### PR DESCRIPTION
### Changes
- Fixed layout overflow on small screens by adjusting OrganizingCommittee section
- Updated logo image sizing for responsive design.

### Testing
- Verified on mobile viewport (320px, 375px, 425px).
- No horizontal scroll present.
<img width="792" height="1508" alt="image" src="https://github.com/user-attachments/assets/cb626abf-a414-4b5c-a5bd-6b8aba262eed" />
